### PR TITLE
헤로쿠에 배포하기 - DB 변경 clearDB -> jaws DB

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -54,7 +54,7 @@ spring:
 spring:
   config.activate.on-profile: heroku
   datasource:
-    url: ${CLEARDB_WHITE_URL}
+    url: ${JAWSDB_URL}
   jpa.hibernate.ddl-auto: create
   sql.init.mode: always
 


### PR DESCRIPTION
jawsDB는 mysql 8.0버전을 지원함.